### PR TITLE
Minimal-process approach to ecosystem map

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,21 @@ Vulkan users. It is meant to facilitate triaging, discussion and routing of
 issues that don't necessarily fit under the scope of a single project within
 the Vulkan ecosystem.
 
+# Map of Vulkan Ecosystem projects
+Vulkan ecosystem is a big place, but there's a lot out there thats useful! In no particular order...
+
+## RenderDoc
+RenderDoc - a graphics debugger, currently available for Vulkan, D3D11, D3D12, and OpenGL development on Windows 7 - 10 and Linux.
+Contacts: [baldurk@baldurk.org](mailto:baldurk@baldurk.org), [#renderdoc on freenode IRC](https://kiwiirc.com/client/irc.freenode.net/#renderdoc)
+Main site: https://renderdoc.org/
+Code: https://github.com/baldurk/renderdoc
+License:  (MIT)[https://github.com/baldurk/renderdoc/blob/v0.x/LICENSE.md]
+Dependencies: MSVC 2015 / gcc 5 / clang 3.4
+Code of conduct: (contributor covenant)[https://github.com/baldurk/renderdoc/blob/v0.x/CODE_OF_CONDUCT.md]
+
+## SPIRV-Tools
+The SPIR-V Tools project provides an API and commands for processing SPIR-V modules.
+
+Contacts: (public_spirv_tools_dev@khronos.org)[https://www.khronos.org/spir/spirv-tools-mailing-list/] || dneto@google.com
+Code: https://github.com/KhronosGroup/SPIRV-Tools
+License: (Apache)[https://github.com/KhronosGroup/SPIRV-Tools/blob/master/LICENSE]


### PR DESCRIPTION
Lets just paste stuff into the readme.md that is useful. Where projects have quirks, we can write what exists. Once we have the map, people can bring up individual issues like "gee, can we talk about eg spirv-tools having a code-of-conduct, or have its dependencies spelled out."